### PR TITLE
adding logic to handle github report format

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Akshay Gupta"
 author = "Akshay Gupta"
 
 # The short X.Y version
-version = "2022.4.0"
+version = "2022.6.0"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/edgetest/__init__.py
+++ b/edgetest/__init__.py
@@ -1,7 +1,7 @@
 """Package initialization."""
 
 
-__version__ = "2022.4.0"
+__version__ = "2022.6.0"
 
 __title__ = "edgetest"
 __description__ = "Bleeding edge dependency testing"

--- a/edgetest/report.py
+++ b/edgetest/report.py
@@ -6,8 +6,10 @@ from tabulate import tabulate
 
 from .core import TestPackage
 
+VALID_OUTPUTS = ["rst", "github"]
 
-def gen_report(testers: List[TestPackage]) -> Any:
+
+def gen_report(testers: List[TestPackage], output_type: str = "rst") -> Any:
     """Generate a rST report.
 
     Parameters
@@ -15,11 +17,17 @@ def gen_report(testers: List[TestPackage]) -> Any:
     testers : list
         A list of ``TestPackage`` objects.
 
+    output_type : str
+        A valid output type of ``rst`` or ``github``
+
     Returns
     -------
     Any
         The report.
     """
+    if output_type not in VALID_OUTPUTS:
+        raise ValueError(f"Invalid output_type provided: {output_type}")
+
     headers = ["Environment", "Passing tests", "Upgraded packages", "Package version"]
     rows: List[List] = []
     for env in testers:
@@ -27,4 +35,4 @@ def gen_report(testers: List[TestPackage]) -> Any:
         for pkg in upgraded:
             rows.append([env.envname, env.status, pkg["name"], pkg["version"]])
 
-    return tabulate(rows, headers=headers, tablefmt="rst")
+    return tabulate(rows, headers=headers, tablefmt=output_type)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,13 @@ license = Apache Software License
 maintainer = Akshay Gupta
 maintainer_email = akshay.gupta2@capitalone.com
 url = https://github.com/capitalone/edgetest
-python_requires = 
+python_requires =
 	>=3.7.0
-project_urls = 
+project_urls =
 	Documentation = https://capitalone.github.io/edgetest/
 	Bug Tracker = https://github.com/capitalone/edgetest/issues
 	Source Code = https://github.com/capitalone/edgetest
-classifiers = 
+classifiers =
 	Intended Audience :: Developers
 	Natural Language :: English
 	Operating System :: OS Independent
@@ -31,7 +31,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-install_requires = 
+install_requires =
 	Cerberus<=1.3.4,>=1.3.0
 	click<=8.1.3,>=7.0
 	pluggy<=1.0.0,>=1.0.0
@@ -39,21 +39,21 @@ install_requires =
 	packaging<=21.3,>20.6
 
 [options.extras_require]
-docs = 
+docs =
 	furo
 	sphinx
 	sphinx-copybutton
 	sphinx-tabs
 	pillow
 	recommonmark
-tests = 
+tests =
 	coverage
 	flake8
 	mypy
 	pydocstyle
 	pytest
 	pytest-cov
-qa = 
+qa =
 	pylint
 	pip-tools
 	pre-commit
@@ -62,12 +62,12 @@ qa =
 	types-click
 	types-pkg_resources
 	types-tabulate
-build = 
+build =
 	build
 	twine
 	wheel
 	bumpver
-dev = 
+dev =
 	coverage
 	flake8
 	mypy
@@ -94,21 +94,21 @@ dev =
 	bumpver
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
 	edgetest = edgetest.interface:cli
 
 [bumpver]
-current_version = "2022.3.1"
+current_version = "2022.6.0"
 version_pattern = "YYYY.MM.INC0"
 commit_message = "Bump {old_version} to {new_version}"
 commit = True
 
 [bumpver:file_patterns]
-docs/source/conf.py = 
+docs/source/conf.py =
 	version = "{version}"
-setup.cfg = 
+setup.cfg =
 	current_version = "{version}"
-edgetest/__init__.py = 
+edgetest/__init__.py =
 	__version__ = "{version}"
 
 [aliases]
@@ -141,21 +141,20 @@ allow_redefinition = True
 pylint_minimum_score = 9.5
 
 [tool:pytest]
-markers = 
+markers =
 	unit: mark unit tests that do not require external interfaces and use mocking
 	integration: mark test that interact with an external system
 addopts = --verbose
 
 [edgetest.envs.core]
 python_version = 3.9
-upgrade = 
+upgrade =
 	Cerberus
 	click
 	pluggy
 	tabulate
 	packaging
-extras = 
+extras =
 	tests
-deps = 
+deps =
 	pip-tools
-

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import pytest
+
+from edgetest.core import TestPackage
+from edgetest.report import gen_report
+
+
+@patch("edgetest.report.tabulate", autospec=True)
+@patch("edgetest.core.TestPackage.upgraded_packages", autospec=True)
+def test_report(mock_test_package, mock_tabulate, plugin_manager):
+    """Test gen_report function"""
+
+    tester_list = [
+        TestPackage(hook=plugin_manager.hook, envname="myenv", upgrade=["myupgrade1"]),
+        TestPackage(hook=plugin_manager.hook, envname="myenv", upgrade=["myupgrade2"]),
+    ]
+    gen_report(tester_list)
+    mock_tabulate.assert_called_with(
+        [],
+        headers=[
+            "Environment",
+            "Passing tests",
+            "Upgraded packages",
+            "Package version",
+        ],
+        tablefmt="rst",
+    )
+
+    gen_report(tester_list, output_type="github")
+    mock_tabulate.assert_called_with(
+        [],
+        headers=[
+            "Environment",
+            "Passing tests",
+            "Upgraded packages",
+            "Package version",
+        ],
+        tablefmt="github",
+    )
+
+    with pytest.raises(ValueError) as e:
+        gen_report(tester_list, output_type="bad")


### PR DESCRIPTION
Fixes #35 

- bumping version
- Updating `gen_report` to allow for report to be sent as `rst` or `github`.
- adding unit test for `gen_report`