### PR TITLE
adding in conf to run_udate hookspec

### DIFF
--- a/edgetest/core.py
+++ b/edgetest/core.py
@@ -124,7 +124,10 @@ class TestPackage:
             f"Upgrading the following packages in {self.envname}: {', '.join(self.upgrade)}"
         )
         self.hook.run_update(
-            basedir=self._basedir, envname=self.envname, upgrade=self.upgrade
+            basedir=self._basedir,
+            envname=self.envname,
+            upgrade=self.upgrade,
+            conf=options,
         )
         LOG.info(f"Successfully upgraded packages in {self.envname}")
 

--- a/edgetest/hookspecs.py
+++ b/edgetest/hookspecs.py
@@ -72,7 +72,7 @@ def create_environment(basedir: str, envname: str, conf: Dict):
 
 
 @hookspec(firstresult=True)
-def run_update(basedir: str, envname: str, upgrade: List):
+def run_update(basedir: str, envname: str, upgrade: List, conf: Dict):
     """Update packages from upgrade list.
 
     Parameters
@@ -83,6 +83,10 @@ def run_update(basedir: str, envname: str, upgrade: List):
         The name of the virtual environment.
     upgrade : list
         The list of packages to upgrade
+    conf : dict
+        The configuration dictionary for the environment. This is useful if you
+        want to add configuration arguments for additional dependencies that can
+        only be installed through the environment manager (e.g. Conda).
 
     Raises
     ------

--- a/edgetest/lib.py
+++ b/edgetest/lib.py
@@ -49,7 +49,7 @@ def create_environment(basedir: str, envname: str, conf: Dict):
 
 
 @hookimpl(trylast=True)
-def run_update(basedir: str, envname: str, upgrade: List):
+def run_update(basedir: str, envname: str, upgrade: List, conf: Dict):
     """Update packages from upgrade list.
 
     Parameters
@@ -60,6 +60,8 @@ def run_update(basedir: str, envname: str, upgrade: List):
         The name of the virtual environment.
     upgrade : list
         The list of packages to upgrade
+    conf : dict
+        Ignored.
 
     Raises
     ------

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -37,11 +37,11 @@ def test_create_environment(mock_env_builder):
 @patch("edgetest.lib._run_command", autospec=True)
 def test_run_update(mock_run):
     python_path = path_to_python("test", "test")
-    run_update("test", "test", ["1", "2"])
+    run_update("test", "test", ["1", "2"], {"test": "test"})
     mock_run.assert_called_with(
         python_path, "-m", "pip", "install", "1", "2", "--upgrade"
     )
 
     mock_run.side_effect = RuntimeError()
     with pytest.raises(RuntimeError):
-        run_update("test", "test", ["1", "2"])
+        run_update("test", "test", ["1", "2"], {"test": "test"})


### PR DESCRIPTION
Small tweak to the `run_update` hookspec to include the `conf` dict for plugins which need them have them.