### PR TITLE
Update `upgraded_packages` get to be case & dash/hyphen insensitive

### DIFF
--- a/edgetest/core.py
+++ b/edgetest/core.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional
 from pluggy._hooks import _HookRelay
 
 from .logger import get_logger
-from .utils import _run_command, pushd
+from .utils import _isin_case_dashhyphen_ins, _run_command, pushd
 
 LOG = get_logger(__name__)
 
@@ -149,7 +149,11 @@ class TestPackage:
         outjson = json.loads(out)
 
         upgrade_wo_extras = [pkg.split("[")[0] for pkg in self.upgrade]
-        return [pkg for pkg in outjson if pkg.get("name", "") in upgrade_wo_extras]
+        return [
+            pkg
+            for pkg in outjson
+            if _isin_case_dashhyphen_ins(pkg.get("name", ""), upgrade_wo_extras)
+        ]
 
     def run_tests(self, command: str) -> int:
         """Run the tests in the package directory.

--- a/edgetest/utils.py
+++ b/edgetest/utils.py
@@ -479,3 +479,24 @@ def upgrade_pyproject_toml(
             parser["project"]["optional-dependencies"][extra] = upgraded.split("\n")  # type: ignore
 
     return parser
+
+
+def _isin_case_dashhyphen_ins(a: str, vals: List[str]) -> bool:
+    """Run isin check that is case and dash/hyphen insensitive.
+
+    Paramaters
+    ----------
+    a : str
+        String value to check for membership against ``vals``.
+    vals : list of str
+        List of strings to check ``a`` against.
+
+    Returns
+    -------
+    bool
+        Return ``True`` if ``a`` in vals, otherwise ``False``.
+    """
+    for b in vals:
+        if a.replace("_", "-").lower() == b.replace("_", "-").lower():
+            return True
+    return False

--- a/tests/test_integration_cfg.py
+++ b/tests/test_integration_cfg.py
@@ -46,7 +46,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    click<=8.0.0,>=7.1
+    scikit-learn>=1.0,<=1.2.0
     dask[dataframe]<=2022.1.0
 
 [options.extras_require]
@@ -57,8 +57,8 @@ tests =
 extras =
     tests
 upgrade =
-    click
-    dask[dataframe]
+    Scikit_Learn
+    Dask[DataFrame]
 """
 
 
@@ -109,6 +109,7 @@ def test_toy_package():
         assert result.exit_code == 0
         assert Path(loc, ".edgetest").is_dir()
         assert Path(loc, ".edgetest", "pandas").is_dir()
+        assert "pandas" in result.stdout
 
         if not sys.platform == "win32":
             assert Path(
@@ -150,13 +151,15 @@ def test_toy_package_dask():
                 loc, ".edgetest", "core", "lib", PY_VER, "site-packages", "pandas"
             ).is_dir()
             assert Path(
-                loc, ".edgetest", "core", "lib", PY_VER, "site-packages", "click"
+                loc, ".edgetest", "core", "lib", PY_VER, "site-packages", "sklearn"
             ).is_dir()
 
         config = configparser.ConfigParser()
         config.read("setup.cfg")
 
-        assert "click" in config["options"]["install_requires"]
+        assert "scikit-learn" in config["options"]["install_requires"]
         assert "dask[dataframe]" in config["options"]["install_requires"]
         assert config["edgetest.envs.core"]["extras"] == "\ntests"
-        assert config["edgetest.envs.core"]["upgrade"] == "\nclick\ndask[dataframe]"
+        assert config["edgetest.envs.core"]["upgrade"] == "\nScikit_Learn\nDask[DataFrame]"
+        assert "dask" in result.stdout
+        assert "scikit-learn" in result.stdout

--- a/tests/test_integration_toml.py
+++ b/tests/test_integration_toml.py
@@ -31,14 +31,14 @@ name = "toy_package"
 version = "0.1.0"
 description = "Fake description"
 requires-python = ">=3.7.0"
-dependencies = ["click<=8.0.0,>=7.1", "dask[dataframe]<=2022.1.0"]
+dependencies = ["Scikit_Learn>=1.0,<=1.2.0", "Dask[dataframe]<=2022.1.0"]
 
 [project.optional-dependencies]
 tests = ["pytest"]
 
 [edgetest.envs.core]
 extras = ["tests"]
-upgrade = ["click", "dask[dataframe]"]
+upgrade = ["scikit-learn", "dask[dataframe]"]
 """
 
 
@@ -89,6 +89,7 @@ def test_toy_package():
         assert result.exit_code == 0
         assert Path(loc, ".edgetest").is_dir()
         assert Path(loc, ".edgetest", "pandas").is_dir()
+        assert "pandas" in result.stdout
 
         if not sys.platform == "win32":
             assert Path(
@@ -130,15 +131,17 @@ def test_toy_package_dask():
                 loc, ".edgetest", "core", "lib", PY_VER, "site-packages", "pandas"
             ).is_dir()
             assert Path(
-                loc, ".edgetest", "core", "lib", PY_VER, "site-packages", "click"
+                loc, ".edgetest", "core", "lib", PY_VER, "site-packages", "sklearn"
             ).is_dir()
 
         config = load(open("pyproject.toml"))
 
-        assert "click" in config["project"]["dependencies"][0]
-        assert "dask" in config["project"]["dependencies"][1]
+        assert "Scikit_Learn" in config["project"]["dependencies"][0]
+        assert "Dask" in config["project"]["dependencies"][1]
         assert config["edgetest"]["envs"]["core"]["extras"] == ["tests"]
         assert config["edgetest"]["envs"]["core"]["upgrade"] == [
-            "click",
+            "scikit-learn",
             "dask[dataframe]",
         ]
+        assert "dask" in result.stdout
+        assert "scikit-learn" in result.stdout

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,4 +488,6 @@ def test_isin_case_dashhyphen_ins():
     vals = ["pandas", "python-dateutil"]
 
     assert _isin_case_dashhyphen_ins("Pandas", vals)
+    assert not _isin_case_dashhyphen_ins("Panda$", vals)
     assert _isin_case_dashhyphen_ins("Python_Dateutil", vals)
+    assert not _isin_case_dashhyphen_ins("Python_Dateut1l", vals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -487,7 +487,10 @@ def test_upgrade_pyproject_toml(tmpdir):
 def test_isin_case_dashhyphen_ins():
     vals = ["pandas", "python-dateutil"]
 
+    assert _isin_case_dashhyphen_ins("pandas", vals)
     assert _isin_case_dashhyphen_ins("Pandas", vals)
     assert not _isin_case_dashhyphen_ins("Panda$", vals)
+    assert _isin_case_dashhyphen_ins("python-dateutil", vals)
     assert _isin_case_dashhyphen_ins("Python_Dateutil", vals)
     assert not _isin_case_dashhyphen_ins("Python_Dateut1l", vals)
+    assert not _isin_case_dashhyphen_ins("pandaspython-dateutil", vals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from edgetest.utils import (
     parse_toml,
     upgrade_pyproject_toml,
     upgrade_setup_cfg,
+    _isin_case_dashhyphen_ins,
 )
 
 REQS = """
@@ -481,3 +482,10 @@ def test_upgrade_pyproject_toml(tmpdir):
             "optional-dependencies": {"tests": ["pytest<=4.0.0,>=1.0.0"]},
         }
     }
+
+
+def test_isin_case_dashhyphen_ins():
+    vals = ["pandas", "python-dateutil"]
+
+    assert _isin_case_dashhyphen_ins("Pandas", vals)
+    assert _isin_case_dashhyphen_ins("Python_Dateutil", vals)


### PR DESCRIPTION
# edgetest version 2023.6.1

## Description

When generating the report, there is a method that gets the list of `upgraded_packages` for a given test environment.
The comparison of your `upgrade` list to your actual test environment (using `pip list`) is currently case sensitive even though `pip list` will always normalize your deps to lowercase with dashes.

This PR changes this comparison to be case and dash/hyphen insensitive to avoid missing upgraded deps due to case/dash differences between your upgrade list and actual env. See issue for more details.

Fixes #63

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
