### PR TITLE
Bump python and version

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -17,10 +17,10 @@ jobs:
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 python-version:
-                    - 3.7
                     - 3.8
                     - 3.9
                     - "3.10"
+                    - "3.11"
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Table Of Contents
 Install
 -------
 
-Create a ``conda`` environment with Python 3.7+ and install from PyPI:
+Create a ``conda`` environment with Python 3.8+ and install from PyPI:
 
 ```console
 $ python -m pip install edgetest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Akshay Gupta"
 author = "Akshay Gupta"
 
 # The short X.Y version
-version = "2023.6.0"
+version = "2023.6.1"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/edgetest/__init__.py
+++ b/edgetest/__init__.py
@@ -1,7 +1,7 @@
 """Package initialization."""
 
 
-__version__ = "2023.6.0"
+__version__ = "2023.6.1"
 
 __title__ = "edgetest"
 __description__ = "Bleeding edge dependency testing"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ maintainer = Akshay Gupta
 maintainer_email = akshay.gupta2@capitalone.com
 url = https://github.com/capitalone/edgetest
 python_requires =
-	>=3.7.0
+	>=3.8.0
 project_urls =
 	Documentation = https://capitalone.github.io/edgetest/
 	Bug Tracker = https://github.com/capitalone/edgetest/issues
@@ -23,10 +23,10 @@ classifiers =
 	Programming Language :: Python
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3 :: Only
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ console_scripts =
 	edgetest = edgetest.interface:cli
 
 [bumpver]
-current_version = "2023.6.0"
+current_version = "2023.6.1"
 version_pattern = "YYYY.MM.INC0"
 commit_message = "Bump {old_version} to {new_version}"
 commit = True


### PR DESCRIPTION
# edgetest version 2023.6.1

## Description

- Bumping a new release `2023.6.1` .
- updating min and max Python versions
