### PR TITLE
Bump version for release

### DIFF
--- a/edgetest/__init__.py
+++ b/edgetest/__init__.py
@@ -1,7 +1,7 @@
 """Package initialization."""
 
 
-__version__ = "2023.6.1"
+__version__ = "2024.2.0"
 
 __title__ = "edgetest"
 __description__ = "Bleeding edge dependency testing"


### PR DESCRIPTION
Edgetest timed runs are failing because I included the new `lower` feature in the setup but never released it. Just bumping version to make a release which should solve these issues.