### PR TITLE
Enable Automatic Package Discovery

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ classifiers =
 [options]
 zip_safe = False
 include_package_data = True
-packages = find:
 install_requires =
 	Cerberus<=1.3.4,>=1.3.0
 	click<=8.1.3,>=7.0


### PR DESCRIPTION
# edgetest version 2024.2.0

## Description

With custom package discovery, Edgetest installations include both the source and the tests directory. Removing configuration of packages in setup.cfg reverts to automatic package discovery, where the tests directory is implictly excluded.

*I believe this is also present in the other edgetest projects (conda, hub, pip-tools), I can make follow-up PRs in those as well after this PR is merged

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
