### PR TITLE
fix: making pyproject formatting optional and updating the uv installation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2021, Akshay Gupta"
 author = "Akshay Gupta"
 
 # The short X.Y version
-version = "2025.1.0"
+version = "2025.8.0"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/edgetest/__init__.py
+++ b/edgetest/__init__.py
@@ -1,6 +1,6 @@
 """Package initialization."""
 
-__version__ = "2025.1.0"
+__version__ = "2025.8.0"
 
 __title__ = "edgetest"
 __description__ = "Bleeding edge dependency testing"

--- a/edgetest/interface.py
+++ b/edgetest/interface.py
@@ -209,7 +209,8 @@ def cli(
                 with open(requirements, "w") as outfile:
                     outfile.write(upgraded)
             # Run the formatter
-            pyproject_fmt.run([config])
+            if "pyproject-fmt" in parser.get("tool", {}):
+                pyproject_fmt.run([config])
         else:
             click.echo(f"Overwriting the requirements file {requirements}...")
             upgraded = upgrade_requirements(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ lower = [
 ]
 
 [bumpver]
-current_version = "2025.1.0"
+current_version = "2025.8.0"
 version_pattern = "YYYY.MM.INC0"
 
 [bumpver.file_patterns]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,13 @@ dynamic = [
 
 dependencies = [
     "cerberus>=1.3.0,<=1.3.7",
-    "click>=7.0,<=8.2.0",
+    "click>=7.0,<=8.2.1",
     "packaging>20.6,<=25.0",
     "pluggy>=1.3.0,<=1.6.0",
-    "pyproject-fmt>=2.0.0,<=2.5.1",
+    "pyproject-fmt>=2.0.0,<=2.6.0",
     "tabulate>=0.8.9,<=0.9.0",
     "tomlkit<=0.11.4,>=0.11.4",
-    "uv>=0.2.0,<=0.7.4",
+    "uv>=0.2.0,<=0.8.13",
 ]
 optional-dependencies.build = [ "build", "bumpver", "twine", "wheel" ]
 optional-dependencies.dev = [
@@ -81,10 +81,6 @@ version = { attr = "edgetest.__version__" }
 readme = { file = [
     "README.md",
 ], content-type = "text/markdown" }
-
-##############################################################################
-# Tooling
-##############################################################################
 
 [tool.ruff]
 target-version = "py39"

--- a/tests/test_integration_toml.py
+++ b/tests/test_integration_toml.py
@@ -22,6 +22,12 @@ tests = ["pytest"]
 
 [edgetest]
 extras = ["tests"]
+
+[tool.pyproject-fmt]
+column_width = 88
+indent = 4
+keep_full_version = true
+max_supported_python = "3.12"
 """
 
 SETUP_TOML_LOWER = """
@@ -40,6 +46,12 @@ extras = ["tests"]
 
 [edgetest.envs.lower_env]
 lower = ["polars"]
+
+[tool.pyproject-fmt]
+column_width = 88
+indent = 4
+keep_full_version = true
+max_supported_python = "3.12"
 """
 
 SETUP_TOML_EXTRAS = """
@@ -60,6 +72,12 @@ upgrade = ["scikit-learn", "polars[pyarrow]"]
 [edgetest.envs.lower_env]
 extras = ["tests"]
 lower = ["scikit-learn", "polars[pyarrow]"]
+
+[tool.pyproject-fmt]
+column_width = 88
+indent = 4
+keep_full_version = true
+max_supported_python = "3.12"
 """
 
 

--- a/tests/test_interface_toml.py
+++ b/tests/test_interface_toml.py
@@ -20,16 +20,7 @@ upgrade = ["myupgrade"]
 command = "pytest tests -m 'not integration'"
 """
 
-SETUP_TOML_LOWER = """
-[project]
-classifiers = [
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-]
+SETUP_TOML_LOWER = """[project]
 dependencies = [
   "myupgrade<=0.1.5",
   "mylower<=0.1,>=0.0.1"
@@ -40,32 +31,15 @@ lower = [ "mylower" ]
 command = "pytest tests -m 'not integration'"
 """
 
-SETUP_TOML_REQS = """
-[project]
+SETUP_TOML_REQS = """[project]
 dependencies = ["myupgrade<=0.1.5"]
 """
 
 SETUP_TOML_REQS_UPGRADE = """[project]
-classifiers = [
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-]
-dependencies = [ "myupgrade<=0.2" ]
+dependencies = ["myupgrade<=0.2.0"]
 """
 
 SETUP_TOML_EXTRAS = """[project]
-classifiers = [
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-]
 optional-dependencies.myextra = [ "myupgrade<=0.1.5" ]
 
 [edgetest.envs.myenv]
@@ -76,15 +50,7 @@ command = "pytest tests -m 'not integration'"
 
 
 SETUP_TOML_EXTRAS_UPGRADE = """[project]
-classifiers = [
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-]
-optional-dependencies.myextra = [ "myupgrade<=0.2" ]
+optional-dependencies.myextra = ["myupgrade<=0.2.0"]
 
 [edgetest.envs.myenv]
 upgrade = [ "myupgrade" ]


### PR DESCRIPTION
## Description

In this PR, I've updated our dependency bounds via `edgetest` and modified the recent formatting functionality to make it optional.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
