### PR TITLE
chore: updating git workflow

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: main
       - id: run-edgetest
         uses: edgetest-dev/run-edgetest-action@v1.6
         with:
           edgetest-flags: '-c pyproject.toml -r requirements.txt --export'
-          base-branch: 'dev'
+          base-branch: 'main'
           skip-pr: 'false'
           add-paths: 'pyproject.toml, requirements.txt'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -4,11 +4,9 @@ name: Python package
 on:
     push:
         branches:
-            - dev
             - main
     pull_request:
         branches:
-            - dev
             - main
 jobs:
     build:
@@ -20,6 +18,7 @@ jobs:
                     - "3.10"
                     - "3.11"
                     - "3.12"
+                    - "3.13"
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -1,26 +1,26 @@
 Developer instructions
 ======================
 
-Guidance for Bleeding edge dependency testing developers
+Guidance for edgetest developers
 
 Pre-Config and Black
 --------------------
 
-For developers, Bleeding edge dependency testing uses `pre-commit <https://pre-commit.com/>`_ to run the
-`black <https://github.com/ambv/black>`_ code formatter before each commit.  In a nutshell what happens is:
+For developers, edgetest uses `pre-commit <https://pre-commit.com/>`_ to run the
+`ruff <https://github.com/astral-sh/ruff>`_ code formatter before each commit.  In a nutshell what happens is:
 
 
 * You edit some code locally, then ``git add`` and ``git commit``
-* As the commit is registered by ``git``\ , the ``pre-commit`` package runs ``black`` on any changed files
+* As the commit is registered by ``git``\ , the ``pre-commit`` package runs ``ruff`` on any changed files
   in the commit.  (You can also run ``pre-commit run --all-files`` to run on all files) and will show
-  as having *failed* if it has made any edits.  If ``black`` has made edits to the edited files, you
+  as having *failed* if it has made any edits.  If ``ruff`` has made edits to the edited files, you
   need to re-add and re-commit those specific files.
 * Then you can ``git push`` to your hearts' content!
-* The ``black`` code formatter forces our hand on code formatting and style - that means that all of
+* The ``ruff`` code formatter forces our hand on code formatting and style - that means that all of
   the code follows the same style, and we can focus on the meat of the issue.
 
-The first time you clone Bleeding edge dependency testing into a new environment, you need to run ``pre-commit install`` after
-pip/conda installation.  You do *not* need pre-commit to just run Bleeding edge dependency testing.  If you have a pre-existing
+The first time you clone edgetest into a new environment, you need to run ``pre-commit install`` after
+pip/conda installation.  You do *not* need pre-commit to just run edgetest  If you have a pre-existing
 environment, go ahead and ``pip install pre-commit`` and you should be fine. Generally,
 only PRs with black styling will be accepted by the Bleeding edge dependency testing team.
 

--- a/docs/source/release_guide.rst
+++ b/docs/source/release_guide.rst
@@ -4,22 +4,18 @@ Release Guide
 Overview
 --------
 
-As part of the on going maintenance of the project having a standardized release
-procedure for our repos is key. We follows as pared down version of git-flow
-which can be read in more detail `here. <https://nvie.com/posts/a-successful-git-branching-model/>`_
-We use ``bumpver`` to automate calendar versioning. To run ``bumpver`` and update
-your branch in preparation for an upcoming release, run ``bumpver update``. This
-will update all necessary files and commit them using ``git``.
+Starting in 2026 we've modified our git workflow.
 
-``dev`` is the default branch where most people will work with day to day.
-All features must be squash merged into this branch. The reason we squash merge
-is to prevent the dev branch from being polluted with endless commit messages
-when people are developing. Squashing collapses all the commits into one single
-new commit. It will also make it much easier to back out changes if something breaks.
+``main`` will be the core branch where all features will get merged into and
+production ready code will also exist. When a release is ready to be made releases/tags will be use
+to point to the commit where the release should be made from.
 
-``main`` is where official releases will go. Each release on ``main`` should
-be tagged properly to denote a "version" that will have the corresponding artifact
-on PyPI for users to ``pip install``.
+In the past we had used ``dev``, in conjunction with ``main``, but there were some issues
+with diverging branches and new rulesets which make the ``main`` only branching strategy
+easier to manage.
+
+Each release on ``main`` should be tagged properly to denote a "version" that will have the
+corresponding artifact on PyPI for users to ``pip install``.
 
 
 ``gh-pages`` is where official documentation will go. After each release you should
@@ -34,14 +30,14 @@ TLDR;
 -----
 
 * Each feature should have its own branch.
-* Each feature branch should be squash merged into ``dev``
+* Each feature branch should be squash merged into ``main``
 * Before a release, bump the version using ``bumpver``.
-* Merge  ``dev`` into ``main`` via a regular "merge commits"
-* Build and push docs ``gh-pages``.
-* Build and push version to PyPI.
+* Create a release from ``main`` via Releases and Tags
+* Build and push docs ``gh-pages``. (automated via actions)
+* Build and push version to PyPI. (automated via actions)
 
 
 .. note::
 
-    ``main``, ``dev``, and ``gh-pages`` should be protected in the GitHub UI
+    ``main``, and ``gh-pages`` should be protected in the GitHub UI
     so they aren't accidentally deleted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
     "readme",
@@ -132,7 +134,7 @@ lint.preview = true
 column_width = 88
 indent = 4
 keep_full_version = true
-max_supported_python = "3.12"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 markers = [

--- a/tests/test_integration_cfg.py
+++ b/tests/test_integration_cfg.py
@@ -15,14 +15,14 @@ name = toy_package
 version = 0.1.0
 description = Fake description
 python_requires =
-    >=3.7.0
+    >=3.10.0
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    polars<=1.0.0
+    polars<=2.0.0
 
 [options.extras_require]
 tests =
@@ -39,14 +39,14 @@ name = toy_package
 version = 0.1.0
 description = Fake description
 python_requires =
-    >=3.7.0
+    >=3.10.0
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    polars>=1.0.0,<=1.5.0
+    polars>=1.30.0,<=1.35.0
 
 [options.extras_require]
 tests =
@@ -68,15 +68,15 @@ name = toy_package
 version = 0.1.0
 description = Fake description
 python_requires =
-    >=3.7.0
+    >=3.10.0
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    scikit-learn>=1.3.2,<=1.4.0
-    polars[pyarrow]>=1.0.0,<=1.5.0
+    scikit-learn>=1.7.0,<=1.7.2
+    polars[pyarrow]>=1.30.0,<=1.35.0
 
 [options.extras_require]
 tests =
@@ -86,15 +86,15 @@ tests =
 extras =
     tests
 upgrade =
-    Scikit_Learn
-    Polars[PyArrow]
+    scikit-learn
+    polars[pyarrow]
 
 [edgetest.envs.lower_env]
 extras =
     tests
 lower =
-    scikit_Learn
-    Polars[pyArrow]
+    scikit-learn
+    polars[pyarrow]
 """
 
 
@@ -233,12 +233,12 @@ def test_toy_package_extras():
         assert "polars[pyarrow]" in config["options"]["install_requires"]
         assert config["edgetest.envs.core"]["extras"] == "\ntests"
         assert (
-            config["edgetest.envs.core"]["upgrade"] == "\nScikit_Learn\nPolars[PyArrow]"
+            config["edgetest.envs.core"]["upgrade"] == "\nscikit-learn\npolars[pyarrow]"
         )
         assert config["edgetest.envs.lower_env"]["extras"] == "\ntests"
         assert (
             config["edgetest.envs.lower_env"]["lower"]
-            == "\nscikit_Learn\nPolars[pyArrow]"
+            == "\nscikit-learn\npolars[pyarrow]"
         )
         assert "polars" in result.stdout
         assert "scikit-learn" in result.stdout

--- a/tests/test_integration_toml.py
+++ b/tests/test_integration_toml.py
@@ -14,7 +14,7 @@ SETUP_TOML = """
 name = "toy_package"
 version = "0.1.0"
 description = "Fake description"
-requires-python = ">=3.7.0"
+requires-python = ">=3.10.0"
 dependencies = ["polars<=1.0.0"]
 
 [project.optional-dependencies]
@@ -27,7 +27,7 @@ extras = ["tests"]
 column_width = 88
 indent = 4
 keep_full_version = true
-max_supported_python = "3.12"
+max_supported_python = "3.14"
 """
 
 SETUP_TOML_LOWER = """
@@ -35,7 +35,7 @@ SETUP_TOML_LOWER = """
 name = "toy_package"
 version = "0.1.0"
 description = "Fake description"
-requires-python = ">=3.7.0"
+requires-python = ">=3.10.0"
 dependencies = ["polars>=1.0.0,<=1.5.0"]
 
 [project.optional-dependencies]
@@ -51,7 +51,7 @@ lower = ["polars"]
 column_width = 88
 indent = 4
 keep_full_version = true
-max_supported_python = "3.12"
+max_supported_python = "3.14"
 """
 
 SETUP_TOML_EXTRAS = """
@@ -59,8 +59,8 @@ SETUP_TOML_EXTRAS = """
 name = "toy_package"
 version = "0.1.0"
 description = "Fake description"
-requires-python = ">=3.7.0"
-dependencies = ["Scikit_Learn>=1.3.2,<=1.4.0", "Polars[pyarrow]>=1.0.0,<=1.5.0"]
+requires-python = ">=3.10.0"
+dependencies = ["Scikit_Learn>=1.7.0,<=1.7.2", "Polars[pyarrow]>=1.0.0,<=1.5.0"]
 
 [project.optional-dependencies]
 tests = ["pytest"]
@@ -77,7 +77,7 @@ lower = ["scikit-learn", "polars[pyarrow]"]
 column_width = 88
 indent = 4
 keep_full_version = true
-max_supported_python = "3.12"
+max_supported_python = "3.14"
 """
 
 


### PR DESCRIPTION
proposal to move to a new git workflow style to help simplify the rule set controls in place in the `capitalone` org.
- remove `dev`
- `features` are squash merged into `main`
- `tags` and `release` denote production versions against `main`
