### PR TITLE
v2026.4.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2025, Akshay Gupta"
 author = "Akshay Gupta"
 
 # The short X.Y version
-version = "2026.1.1"
+version = "2026.4.0"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/edgetest/__init__.py
+++ b/edgetest/__init__.py
@@ -1,6 +1,6 @@
 """Package initialization."""
 
-__version__ = "2026.1.1"
+__version__ = "2026.4.0"
 
 __title__ = "edgetest"
 __description__ = "Bleeding edge dependency testing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ lower = [
 ]
 
 [bumpver]
-current_version = "2026.1.1"
+current_version = "2026.4.0"
 version_pattern = "YYYY.MM.INC0"
 
 [bumpver.file_patterns]


### PR DESCRIPTION
## Description

In this release, we are integrating `uv` into `edgetest` more and more. We are using `uv` for virtual environment management (#132) as well as automatically updating a `uv.lock` file (if present) when exporting updated requirements (#137).

