### PR TITLE
feat: implementing dependency cooldowns via UV

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -407,6 +407,35 @@ your end output should look something like this:
     Testing multiple local packages is only supported with the configuration file syntax.
 
 
+Implementing a dependency cooldown
+----------------------------------
+
+`Dependency cooldowns <https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns>`_ allow
+users to prevent ``edgetest`` from installing newly released upgrades in the interest of supply chain security.
+To use this feature, specify ``exclude_newer`` in your configuration. Documentation on this parameter can be found
+in the ``uv`` documentation `here <https://docs.astral.sh/uv/reference/cli/#uv-pip-install--exclude-newer>`_.
+
+.. tabs::
+
+    .. tab:: .cfg
+
+        Add ``exclude_newer`` to your environment or default configuration:
+
+        .. code-block:: ini
+
+            [edgetest]
+            exclude_newer =
+                3 days
+
+    .. tab:: .toml
+
+        Add ``exclude_newer`` to your environment or default configuration:
+
+        .. code-block:: toml
+
+            [edgetest]
+            exclude_newer = "3 days"
+
 Running a single environment
 ----------------------------
 
@@ -580,7 +609,7 @@ and maintained by the ``edgetest`` developer team:
 |                                                                          |                                                                    |
 +==========================================================================+====================================================================+
 | `edgetest-conda <https://github.com/capitalone/edgetest-conda>`_         | | Uses ``conda`` or ``mamba`` for environment creation instead of  |
-|                                                                          | | ``uv``.                                                        |
+|                                                                          | | ``uv``.                                                          |
 +--------------------------------------------------------------------------+--------------------------------------------------------------------+
 | `edgetest-hub <https://github.com/capitalone/edgetest-hub>`_             | | Creates a pull request in your GitHub repository with the        |
 |                                                                          | | dependency updates.                                              |

--- a/edgetest/lib.py
+++ b/edgetest/lib.py
@@ -86,7 +86,7 @@ def run_update(basedir: str, envname: str, upgrade: List, conf: Dict):
         "--upgrade",
     ]
     if (cooldown_ := conf.get("exclude_newer")) is not None:
-        callargs_.append(f"--exclude-newer='{cooldown_}'")
+        callargs_.append(f"--exclude-newer={cooldown_}")
     try:
         _run_command(*callargs_)
     except Exception as err:

--- a/edgetest/lib.py
+++ b/edgetest/lib.py
@@ -68,7 +68,8 @@ def run_update(basedir: str, envname: str, upgrade: List, conf: Dict):
     upgrade : list
         The list of packages to upgrade
     conf : dict
-        Ignored.
+        The configuration dictionary. The configuration is parsed for ``exclude_newer``,
+        which maps to the parameter of the same name in ``uv``.
 
     Raises
     ------
@@ -76,10 +77,18 @@ def run_update(basedir: str, envname: str, upgrade: List, conf: Dict):
         Error raised if the packages cannot be updated.
     """
     python_path = path_to_python(basedir, envname)
+    callargs_ = [
+        "uv",
+        "pip",
+        "install",
+        f"--python={python_path}",
+        *upgrade,
+        "--upgrade",
+    ]
+    if (cooldown_ := conf.get("exclude_newer")) is not None:
+        callargs_.append(f"--exclude-newer='{cooldown_}'")
     try:
-        _run_command(
-            "uv", "pip", "install", f"--python={python_path}", *upgrade, "--upgrade"
-        )
+        _run_command(*callargs_)
     except Exception as err:
         raise RuntimeError(f"Unable to pip upgrade: {upgrade}") from err
 

--- a/edgetest/schema.py
+++ b/edgetest/schema.py
@@ -12,6 +12,12 @@ BASE_SCHEMA = {
             "type": "dict",
             "schema": {
                 "name": {"type": "string", "coerce": "strip", "required": True},
+                "exclude_newer": {
+                    "type": "string",
+                    "coerce": "strip",
+                    "default": None,
+                    "nullable": True,
+                },
                 "upgrade": {
                     "type": "list",
                     "schema": {

--- a/tests/test_interface_cfg.py
+++ b/tests/test_interface_cfg.py
@@ -22,6 +22,18 @@ command =
     pytest tests -m 'not integration'
 """
 
+
+SETUP_CFG_COOLDOWN = """[edgetest]
+exclude_newer =
+    3 days
+
+[edgetest.envs.myenv]
+upgrade =
+    myupgrade
+command =
+    pytest tests -m 'not integration'
+"""
+
 SETUP_CFG_LOWER = """
 [options]
 install_requires =
@@ -159,6 +171,82 @@ def test_cli_basic(mock_popen, mock_cpopen):
         ),
         call(
             ("uv", "pip", "install", f"--python={py_loc!s}", "myupgrade", "--upgrade"),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+        call(
+            ("uv", "pip", "list", f"--python={py_loc!s}", "--format", "json"),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+    ]
+    assert mock_cpopen.call_args_list == [
+        call(
+            (
+                f"{py_loc!s}",
+                "-m",
+                "pytest",
+                "tests",
+                "-m",
+                "not integration",
+            ),
+            universal_newlines=True,
+        )
+    ]
+
+    assert result.output == TABLE_OUTPUT
+
+
+@patch("edgetest.core.Popen", autospec=True)
+@patch("edgetest.utils.Popen", autospec=True)
+def test_cli_basic_cooldown(mock_popen, mock_cpopen):
+    """Test creating a basic environment with dependency cooldowns."""
+    mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
+    type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
+    mock_cpopen.return_value.communicate.return_value = ("output", "error")
+    type(mock_cpopen.return_value).returncode = PropertyMock(return_value=0)
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem() as loc:
+        with open("setup.cfg", "w") as outfile:
+            outfile.write(SETUP_CFG_COOLDOWN)
+
+        result = runner.invoke(cli, ["--config=setup.cfg"])
+
+    assert result.exit_code == 0
+
+    env_loc = Path(loc) / ".edgetest" / "myenv"
+    if platform.system() == "Windows":
+        py_loc = env_loc / "Scripts" / "python.exe"
+    else:
+        py_loc = env_loc / "bin" / "python"
+
+    assert mock_popen.call_args_list == [
+        call(
+            ("uv", "venv", str(env_loc)),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+        call(
+            ("uv", "pip", "install", f"--python={py_loc!s}", "."),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+        call(
+            (
+                "uv",
+                "pip",
+                "install",
+                f"--python={py_loc!s}",
+                "myupgrade",
+                "--upgrade",
+                "--exclude-newer='3 days'",
+            ),
             stdout=-1,
             stderr=-1,
             universal_newlines=True,

--- a/tests/test_interface_cfg.py
+++ b/tests/test_interface_cfg.py
@@ -245,7 +245,7 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
                 f"--python={py_loc!s}",
                 "myupgrade",
                 "--upgrade",
-                "--exclude-newer='3 days'",
+                "--exclude-newer=3 days",
             ),
             stdout=-1,
             stderr=-1,

--- a/tests/test_interface_toml.py
+++ b/tests/test_interface_toml.py
@@ -238,7 +238,7 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
                 f"--python={py_loc!s}",
                 "myupgrade",
                 "--upgrade",
-                "--exclude-newer='3 days'",
+                "--exclude-newer=3 days",
             ),
             stdout=-1,
             stderr=-1,

--- a/tests/test_interface_toml.py
+++ b/tests/test_interface_toml.py
@@ -20,6 +20,14 @@ upgrade = ["myupgrade"]
 command = "pytest tests -m 'not integration'"
 """
 
+SETUP_TOML_COOLDOWN = """[edgetest]
+exclude_newer = "3 days"
+
+[edgetest.envs.myenv]
+upgrade = ["myupgrade"]
+command = "pytest tests -m 'not integration'"
+"""
+
 SETUP_TOML_LOWER = """[project]
 dependencies = [
   "myupgrade<=0.1.5",
@@ -155,6 +163,82 @@ def test_cli_basic(mock_popen, mock_cpopen):
                 f"--python={py_loc!s}",
                 "myupgrade",
                 "--upgrade",
+            ),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+        call(
+            ("uv", "pip", "list", f"--python={py_loc!s}", "--format", "json"),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+    ]
+    assert mock_cpopen.call_args_list == [
+        call(
+            (
+                f"{py_loc!s}",
+                "-m",
+                "pytest",
+                "tests",
+                "-m",
+                "not integration",
+            ),
+            universal_newlines=True,
+        )
+    ]
+
+    assert result.output == TABLE_OUTPUT
+
+
+@patch("edgetest.core.Popen", autospec=True)
+@patch("edgetest.utils.Popen", autospec=True)
+def test_cli_basic_cooldown(mock_popen, mock_cpopen):
+    """Test creating a basic environment with dependency cooldowns."""
+    mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
+    type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
+    mock_cpopen.return_value.communicate.return_value = ("output", "error")
+    type(mock_cpopen.return_value).returncode = PropertyMock(return_value=0)
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem() as loc:
+        with open("pyproject.toml", "w") as outfile:
+            outfile.write(SETUP_TOML_COOLDOWN)
+
+        result = runner.invoke(cli, ["--config=pyproject.toml"])
+
+    assert result.exit_code == 0
+
+    env_loc = Path(loc) / ".edgetest" / "myenv"
+    if platform.system() == "Windows":
+        py_loc = env_loc / "Scripts" / "python.exe"
+    else:
+        py_loc = env_loc / "bin" / "python"
+
+    assert mock_popen.call_args_list == [
+        call(
+            ("uv", "venv", str(env_loc)),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+        call(
+            ("uv", "pip", "install", f"--python={py_loc!s}", "."),
+            stdout=-1,
+            stderr=-1,
+            universal_newlines=True,
+        ),
+        call(
+            (
+                "uv",
+                "pip",
+                "install",
+                f"--python={py_loc!s}",
+                "myupgrade",
+                "--upgrade",
+                "--exclude-newer='3 days'",
             ),
             stdout=-1,
             stderr=-1,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,6 +124,17 @@ extras = ["tests"]
 command = "pytest tests -m 'not integration'"
 """
 
+TOML_REQS_COOLDOWN = """
+[project]
+dependencies = [
+    "myupgrade"
+]
+[edgetest]
+extras = ["tests"]
+command = "pytest tests -m 'not integration'"
+exclude_newer = "3 days"
+"""
+
 TOML_NOREQS_DEFAULTS = """
 [edgetest]
 extras = ["tests"]
@@ -472,6 +483,35 @@ def test_parse_toml_reqs_default(tmpdir):
     validator = EdgetestValidator(schema=BASE_SCHEMA)
 
     assert validator.validate(toml)
+
+
+def test_parse_toml_cooldown(tmpdir):
+    """Test parsing a config with a dependency cooldown."""
+    location = tmpdir.mkdir("mylocation")
+    conf_loc = Path(str(location), "myconfig.toml")
+    with open(conf_loc, "w") as outfile:
+        outfile.write(TOML_REQS_COOLDOWN)
+
+    toml = parse_toml(filename=conf_loc)
+
+    assert toml == {
+        "envs": [
+            {
+                "name": "myupgrade",
+                "upgrade": "myupgrade",
+                "extras": "tests",
+                "command": "pytest tests -m 'not integration'",
+                "exclude_newer": "3 days",
+            },
+            {
+                "name": "all-requirements",
+                "upgrade": "myupgrade",
+                "extras": "tests",
+                "command": "pytest tests -m 'not integration'",
+                "exclude_newer": "3 days",
+            },
+        ]
+    }
 
 
 def test_parse_custom_toml(tmpdir):


### PR DESCRIPTION
## Description

In this PR, I've added the ability for users to limit edgetest from installing brand-new PyPI releases. This feature is useful for users concerned with supply chain attacks.

Fixes #140

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
