### PR TITLE
feat: adding a CLI flag to ignore dependency cooldowns without changing the configuration

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -436,6 +436,15 @@ in the ``uv`` documentation `here <https://docs.astral.sh/uv/reference/cli/#uv-p
             [edgetest]
             exclude_newer = "3 days"
 
+.. important::
+
+    If you want to bypass the dependency cooldown *without* changing your core configuration,
+    you can use the ``--ignore-cooldown`` CLI flag.
+
+    .. code-block:: bash
+
+        edgetest -c pyproject.toml --ignore-cooldown
+
 Running a single environment
 ----------------------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -49,7 +49,7 @@ You can also specify your testing environment through ``setup.cfg`` or ``pyproje
             upgrade =
                 pandas
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         .. code-block:: toml
 
@@ -57,6 +57,14 @@ You can also specify your testing environment through ``setup.cfg`` or ``pyproje
             upgrade = [
                 "pandas"
             ]
+
+    .. tab:: .toml (modern)
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            upgrade = [ "pandas" ]
 
 If you're using a `PEP-517 <https://setuptools.pypa.io/en/latest/userguide/declarative_config.html>`_
 or `PEP-621 <https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html>`_ style installation configuration
@@ -122,7 +130,7 @@ call as follows:
             extras =
                 tests
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         Add an ``extras`` list to your environment:
 
@@ -131,6 +139,17 @@ call as follows:
             [edgetest.envs.pandas]
             upgrade = ["myupgrade"]
             extras = ["tests"]
+
+    .. tab:: .toml (modern)
+
+        Add an ``extras`` list to your environment:
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            upgrade = [ "myupgrade" ]
+            extras = [ "tests" ]
 
     .. tab:: Requirements parsing
 
@@ -160,7 +179,7 @@ To specify the python version for your virtual environments, modify your configu
                 pandas
             python_version = "3.13"
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         Add ``python_version`` to your environment:
 
@@ -168,6 +187,17 @@ To specify the python version for your virtual environments, modify your configu
 
             [edgetest.envs.pandas]
             upgrade = ["pandas"]
+            python_version = "3.10"
+
+    .. tab:: .toml (modern)
+
+        Add ``python_version`` to your environment:
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            upgrade = [ "pandas" ]
             python_version = "3.10"
 
 Modifying the test command
@@ -191,7 +221,7 @@ To customize your test command, modify the configuration or CLI call as follows:
             command =
                 pytest tests -m 'not integration'
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         Add a ``command`` key to your environment:
 
@@ -200,6 +230,18 @@ To customize your test command, modify the configuration or CLI call as follows:
             [edgetest.envs.pandas]
             upgrade = ["myupgrade"]
             extras = ["tests"]
+            command = "pytest tests -m 'not integration'"
+
+    .. tab:: .toml (modern)
+
+        Add a ``command`` key to your environment:
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            upgrade = [ "myupgrade" ]
+            extras = [ "tests" ]
             command = "pytest tests -m 'not integration'"
 
     .. tab:: Requirements parsing
@@ -240,7 +282,7 @@ To specify additional ``pip`` dependencies, modify as follows:
             deps =
                 scikit-learn
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         Add a ``deps`` list:
 
@@ -251,6 +293,19 @@ To specify additional ``pip`` dependencies, modify as follows:
             extras = ["tests"]
             command = "pytest tests -m 'not integration'"
             deps = ["scikit-learn"]
+
+    .. tab:: .toml (modern)
+
+        Add a ``deps`` list:
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            upgrade = [ "myupgrade" ]
+            extras = [ "tests" ]
+            command = "pytest tests -m 'not integration'"
+            deps = [ "scikit-learn" ]
 
     .. tab:: Requirements parsing
 
@@ -330,7 +385,7 @@ you can specify those under the ``edgetest`` section of your configuration:
             will apply the default arguments to each environment.
 
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         .. code-block:: toml
 
@@ -344,6 +399,21 @@ you can specify those under the ``edgetest`` section of your configuration:
             [edgetest.envs.numpy]
             upgrade = ["numpy"]
 
+    .. tab:: .toml (modern)
+
+        .. code-block:: toml
+
+            [tool.edgetest]
+            extras = [ "tests" ]
+            command = "pytest tests -m 'not integration'"
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            upgrade = [ "pandas" ]
+
+            [[tool.edgetest.env]]
+            name = "numpy"
+            upgrade = [ "numpy" ]
 
 Multiple packages
 -----------------
@@ -373,7 +443,7 @@ in your testing project directory:
 
             $ edgetest -c path/to/edgetest.cfg
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         .. code-block:: toml
 
@@ -384,6 +454,26 @@ in your testing project directory:
             [edgetest.envs.numpy]
             package_dir = "../myotherpackage"
             upgrade = ["numpy"]
+
+        After running
+
+        .. code-block:: console
+
+            $ edgetest -c path/to/edgetest.toml
+
+    .. tab:: .toml (modern)
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas"
+            package_dir = "../mypackage"
+            upgrade = [ "pandas" ]
+
+            [[tool.edgetest.env]]
+            name = "numpy"
+            package_dir = "../myotherpackage"
+            upgrade = [ "numpy" ]
 
         After running
 
@@ -427,13 +517,22 @@ in the ``uv`` documentation `here <https://docs.astral.sh/uv/reference/cli/#uv-p
             exclude_newer =
                 3 days
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         Add ``exclude_newer`` to your environment or default configuration:
 
         .. code-block:: toml
 
             [edgetest]
+            exclude_newer = "3 days"
+
+    .. tab:: .toml (modern)
+
+        Add ``exclude_newer`` to your environment or default configuration:
+
+        .. code-block:: toml
+
+            [tool.edgetest]
             exclude_newer = "3 days"
 
 .. important::
@@ -542,7 +641,7 @@ You can use an edgetest environment to test the lower bounds of dependencies in 
             lower =
                 pandas
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         .. code-block:: toml
 
@@ -550,6 +649,14 @@ You can use an edgetest environment to test the lower bounds of dependencies in 
             lower = [
                 "pandas"
             ]
+
+    .. tab:: .toml (modern)
+
+        .. code-block:: toml
+
+            [[tool.edgetest.env]]
+            name = "pandas_lower"
+            lower = [ "pandas" ]
 
 Running the edgetest command using this environment specification will:
 
@@ -574,7 +681,7 @@ For example, if your project configuration looks like this:
             lower =
                 pandas
 
-    .. tab:: .toml
+    .. tab:: .toml (legacy)
 
         .. code-block:: toml
 
@@ -584,8 +691,22 @@ For example, if your project configuration looks like this:
             ]
 
             [edgetest.envs.pandas_lower]
-            lower =
-                pandas
+            lower = [
+                "pandas"
+            ]
+
+    .. tab:: .toml (modern)
+
+        .. code-block:: toml
+
+            [project]
+            dependencies = [
+                "pandas>=0.24.3",
+            ]
+
+            [[tool.edgetest.env]]
+            name = "pandas_lower"
+            lower = [ "pandas" ]
 
 then edgetest will:
 

--- a/edgetest/interface.py
+++ b/edgetest/interface.py
@@ -100,6 +100,11 @@ def get_plugin_manager() -> pluggy.PluginManager:
     is_flag=True,
     help="Whether or not to export the updated requirements file. Overwrites input requirements.",
 )
+@click.option(
+    "--ignore-cooldown",
+    is_flag=True,
+    help="Allow the user to bypass the 'dependency cooldown' that may be implemented via `uv`'s ``exclude-newer`` parameter",
+)
 def cli(
     config,
     requirements,
@@ -110,6 +115,7 @@ def cli(
     deps,
     command,
     export,
+    ignore_cooldown,
 ):
     """Create the environments and test.
 

--- a/edgetest/lib.py
+++ b/edgetest/lib.py
@@ -85,7 +85,10 @@ def run_update(basedir: str, envname: str, upgrade: List, conf: Dict):
         *upgrade,
         "--upgrade",
     ]
-    if (cooldown_ := conf.get("exclude_newer")) is not None:
+    ctx = click.get_current_context()
+    if (cooldown_ := conf.get("exclude_newer")) is not None and not ctx.params[
+        "ignore_cooldown"
+    ]:
         callargs_.append(f"--exclude-newer={cooldown_}")
     try:
         _run_command(*callargs_)

--- a/edgetest/utils.py
+++ b/edgetest/utils.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import Dict, List, Tuple
 
+import tomlkit
 from packaging.requirements import Requirement
 from packaging.specifiers import Specifier, SpecifierSet
-from tomlkit import TOMLDocument, load
 from tomlkit.items import Table
 
 from edgetest.logger import get_logger
@@ -341,10 +341,11 @@ def parse_toml(
     options: dict
     # Read in the configuration file
     with open(filename) as buf:
-        config: TOMLDocument = load(buf)
+        config: tomlkit.TOMLDocument = tomlkit.load(buf)
     # Check for ``[tool.edgetest]`` or ``[edgetest]``
-    if "edgetest" in config.get("tool", {}):
-        output, options = _parse_toml_tool(config["tool"]["edgetest"])
+    config_: Table
+    if (config_ := config.get("tool", tomlkit.table()).get("edgetest")) is not None:
+        output, options = _parse_toml_tool(config_)
     elif "edgetest" in config:
         warnings.warn(
             (
@@ -354,7 +355,8 @@ def parse_toml(
             DeprecationWarning,
             stacklevel=2,
         )
-        output, options = _parse_toml_classic(config["edgetest"])
+        config_ = config.get("edgetest", tomlkit.table())
+        output, options = _parse_toml_classic(config_)
     else:
         output = {"envs": []}
         options = {}
@@ -363,10 +365,13 @@ def parse_toml(
         if (
             "lower" in env
             and "project" in config
-            and "dependencies" in config["project"]
+            and "dependencies" in config.get("project", tomlkit.array())
         ):
             output["envs"][idx]["lower"] = get_lower_bounds(
-                dict(config["project"])["dependencies"], output["envs"][idx]["lower"]
+                config.get("project", tomlkit.table())
+                .get("dependencies", tomlkit.array())
+                .unwrap(),
+                output["envs"][idx]["lower"],
             )
 
     if len(output["envs"]) == 0:
@@ -416,8 +421,8 @@ def _parse_toml_classic(config: Table) -> Tuple[Dict, Dict]:
     output: Dict = {"envs": []}
     for section in config:
         if section == "envs":
-            for name, env in config["envs"].items():
-                output["envs"].append({**env.unwrap(), "name": name})
+            for name, env in config.get("envs", tomlkit.table()).unwrap().items():
+                output["envs"].append({**env, "name": name})
         elif isinstance(config[section], Table):
             output[section] = config[section].unwrap()
 
@@ -556,7 +561,7 @@ def upgrade_setup_cfg(
 
 def upgrade_pyproject_toml(
     upgraded_packages: List[Dict[str, str]], filename: str = "pyproject.toml"
-) -> TOMLDocument:
+) -> tomlkit.TOMLDocument:
     """Upgrade the ``pyproject.toml`` file.
 
     Parameters
@@ -572,7 +577,7 @@ def upgrade_pyproject_toml(
         The updated TOMLDocument.
     """
     with open(filename) as buf:
-        parser: TOMLDocument = load(buf)
+        parser: tomlkit.TOMLDocument = tomlkit.load(buf)
     if "project" in parser and parser.get("project").get("dependencies"):  # type: ignore
         LOG.info(f"Updating the requirements in {filename}")
         upgraded = upgrade_requirements(

--- a/edgetest/utils.py
+++ b/edgetest/utils.py
@@ -1,18 +1,17 @@
 """Utility functions."""
 
 import os
+import warnings
 from configparser import ConfigParser
 from contextlib import contextmanager
-from copy import deepcopy
 from pathlib import Path
 from subprocess import PIPE, Popen
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 from packaging.requirements import Requirement
 from packaging.specifiers import Specifier, SpecifierSet
 from tomlkit import TOMLDocument, load
-from tomlkit.container import Container
-from tomlkit.items import Array, Item, String, Table
+from tomlkit.items import Table
 
 from edgetest.logger import get_logger
 
@@ -67,15 +66,6 @@ def pushd(new_dir: str):
         yield
     finally:
         os.chdir(curr_dir)
-
-
-def _convert_toml_array_to_string(item: Item | Any) -> str:
-    if isinstance(item, Array):
-        return "\n".join(item)
-    elif isinstance(item, String):
-        return str(item)
-    else:
-        raise ValueError
 
 
 def convert_requirements(requirements: str, conf: Dict | None = None) -> Dict:
@@ -256,49 +246,83 @@ def parse_toml(
 ) -> Dict:
     """Generate a configuration from a ``.toml`` style file.
 
-    This function can operate in two ways. First, it will look for tables that
-    start with ``edgetest`` and build a configuration. Suppose
-    you have ``pyproject.toml`` as follows:
+    This function will look for a table that starts with either ``edgetest``
+    or ``tool.edgetest``:
 
-    .. code-block:: toml
+    .. tabs::
 
-        [edgetest.envs.pandas]
-        upgrade = [
-            "pandas"
-        ]
+        .. tab:: legacy
+
+            .. code-block:: toml
+
+                [edgetest.envs.pandas]
+                upgrade = [ "pandas" ]
+
+        .. tab:: ``tool``-style
+
+            .. code-block:: toml
+
+                [[tool.edgetest.env]]
+                name = "pandas"
+                upgrade = [ "pandas" ]
 
     This will result in a configuration that has one testing environment, named
     ``pandas``, that upgrades the ``pandas`` package.
 
-    If you don't have any tables that start with ``edgetest.envs``, we will look for
-    the installation requirements (the ``dependencies`` key within the ``project`` section).
-    To set global defaults for you environments, use the ``edgetest`` table:
+    If you don't have any tables that start with ``edgetest.envs`` or entries under the
+    name ``tool.edgetest.env``, we will look for the installation requirements (the ``dependencies``
+    key within the ``project`` section). To set the global defaults for your environments, use
+    the ``edgetest`` or ``tool.edgetest`` table:
 
-    .. code-block:: toml
+    .. tabs::
 
-        [edgetest]
-        extras = [
-            "tests"
-        ]
-        command = "pytest tests -m 'not integration'"
+        .. tab:: legacy
 
-        [edgetest.envs.pandas]
-        upgrade = [
-            "pandas"
-        ]
+            .. code-block:: toml
+
+                [edgetest]
+                extras = [ "tests" ]
+                command = "pytest tests -m 'not integration'"
+
+                [edgetest.envs.pandas]
+                upgrade = [ "pandas" ]
+
+        .. tab:: ``tool``-style
+
+            .. code-block:: toml
+
+                [tool.edgetest]
+                extras = [ "tests" ]
+                command = "pytest tests -m 'not integration'"
+
+                [[tool.edgetest.env]]
+                name = "pandas"
+                upgrade = [ "pandas" ]
 
     For this single environment file, the above configuration is equivalent to
 
-    .. code-block:: toml
+    .. tabs::
 
-        [edgetest.envs.pandas]
-        extras = [
-            "tests"
-        ]
-        command = "pytest tests -m 'not integration'"
-        upgrade = [
-            "pandas"
-        ]
+        .. tab:: legacy
+
+            .. code-block:: toml
+
+                [edgetest.envs.pandas]
+                extras = [
+                    "tests"
+                ]
+                command = "pytest tests -m 'not integration'"
+                upgrade = [
+                    "pandas"
+                ]
+
+        .. tab:: ``tool``-style
+
+                [[tool.edgetest.env]]
+                name = "pandas"
+                extras = [ "tests" ]
+                command = "pytest tests -m 'not integration'"
+                upgrade = [ "pandas" ]
 
     Parameters
     ----------
@@ -314,53 +338,36 @@ def parse_toml(
     Dict
         A configuration dictionary for ``edgetest``.
     """
-    options: Item | Container | dict
+    options: dict
     # Read in the configuration file
     with open(filename) as buf:
         config: TOMLDocument = load(buf)
-    # Parse
-    output: Dict = {"envs": []}
-    # Get any global options if necessary. First scan through and pop out any Tables
-    temp_config = deepcopy(config)
-    if "edgetest" in config:
-        for j in config["edgetest"].items():  # type: ignore
-            if isinstance(config["edgetest"][j[0]], Table):  # type: ignore
-                _ = temp_config["edgetest"].pop(  # type: ignore
-                    j[0], None
-                )  # remove Tables from the temp config
-            else:
-                temp_config["edgetest"][j[0]] = _convert_toml_array_to_string(  # type: ignore
-                    temp_config["edgetest"][j[0]]  # type: ignore
-                )
-        options = temp_config["edgetest"]
+    # Check for ``[tool.edgetest]`` or ``[edgetest]``
+    if "edgetest" in config.get("tool", {}):
+        output, options = _parse_toml_tool(config["tool"]["edgetest"])
+    elif "edgetest" in config:
+        warnings.warn(
+            (
+                "The [edgetest] configuration format has been deprecated. Please "
+                "use [tool.edgetest] and [[tool.edgetest.env]] in the future."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        output, options = _parse_toml_classic(config["edgetest"])
     else:
+        output = {"envs": []}
         options = {}
 
-    # Check envs exists and any other Tables
-    if "edgetest" in config:
-        for section in config["edgetest"]:  # type: ignore
-            if section == "envs":
-                for env in config["edgetest"]["envs"]:  # type: ignore
-                    for item in config["edgetest"]["envs"][env]:  # type: ignore
-                        # If an Array then decompose to a string format
-                        config["edgetest"]["envs"][env][  # type: ignore
-                            item
-                        ] = _convert_toml_array_to_string(
-                            config["edgetest"]["envs"][env][item]  # type: ignore
-                        )
-                    output["envs"].append(dict(config["edgetest"]["envs"][env]))  # type: ignore
-                    output["envs"][-1]["name"] = env
-                    if (
-                        "lower" in output["envs"][-1]
-                        and "project" in config
-                        and "dependencies" in config["project"]  # type: ignore
-                    ):
-                        output["envs"][-1]["lower"] = get_lower_bounds(
-                            dict(config["project"])["dependencies"],  # type: ignore
-                            output["envs"][-1]["lower"],
-                        )
-            elif isinstance(config["edgetest"][section], Table):  # type: ignore
-                output[section] = dict(config["edgetest"][section])  # type: ignore
+    for idx, env in enumerate(output["envs"]):
+        if (
+            "lower" in env
+            and "project" in config
+            and "dependencies" in config["project"]
+        ):
+            output["envs"][idx]["lower"] = get_lower_bounds(
+                dict(config["project"])["dependencies"], output["envs"][idx]["lower"]
+            )
 
     if len(output["envs"]) == 0:
         if config.get("project").get("dependencies"):  # type: ignore
@@ -381,6 +388,74 @@ def parse_toml(
         )
 
     return output
+
+
+def _parse_toml_classic(config: Table) -> Tuple[Dict, Dict]:
+    """Generate a configuration from a ``.toml`` style file.
+
+    This function is used to parse the classic ``edgetest`` table format.
+
+    Parameters
+    ----------
+    config : Table
+        The contents of ``[tool.edgetest]`` in the source TOML document.
+
+    Returns
+    -------
+    Dict
+        A configuration dictionary for ``edgetest``.
+    Dict
+        Global configuration options for ``edgetest``.
+    """
+    options = {
+        key: value.unwrap()
+        for key, value in config.items()
+        if not isinstance(value, Table)
+    }
+
+    output: Dict = {"envs": []}
+    for section in config:
+        if section == "envs":
+            for name, env in config["envs"].items():
+                output["envs"].append({**env.unwrap(), "name": name})
+        elif isinstance(config[section], Table):
+            output[section] = config[section].unwrap()
+
+    return output, options
+
+
+def _parse_toml_tool(config: Table) -> Tuple[Dict, Dict]:
+    """Generate a configuration from a ``.toml`` style configuration.
+
+    This function is used to parse the newer ``tool.edgetest`` table format.
+
+    Parameters
+    ----------
+    config : Table
+        The contents of ``[tool.edgetest]`` in the source TOML document.
+
+    Returns
+    -------
+    Dict
+        A basic configuration dictionary for ``edgetest``.
+    Dict
+        Global configuration options for ``edgetest``.
+    """
+    # Get any global options, if provided. First scan through and pop out any Tables
+    options = {
+        key: value.unwrap()
+        for key, value in config.items()
+        if key != "env" and not isinstance(value, Table)
+    }
+
+    output: Dict = {"envs": []}
+    for section in config:
+        if section == "env":
+            output["envs"] = config["env"].unwrap()
+        elif isinstance(config[section], Table):
+            output[section] = config[section].unwrap()
+
+    return output, options
 
 
 def upgrade_requirements(
@@ -535,7 +610,7 @@ def _isin_case_dashhyphen_ins(a: str, vals: List[str]) -> bool:
     return any(a.replace("_", "-").lower() == b.replace("_", "-").lower() for b in vals)
 
 
-def get_lower_bounds(requirements: str | List[str], lower: str) -> str:
+def get_lower_bounds(requirements: str | List[str], lower: str | List[str]) -> str:
     r"""Get lower bounds of requested packages from installation requirements.
 
     Parses through the project ``requirements`` and the newline-delimited
@@ -546,7 +621,7 @@ def get_lower_bounds(requirements: str | List[str], lower: str) -> str:
     requirements : str or list
         Project setup requirements,
         e.g. ``"pandas>=1.5.1,<=1.4.2\nnumpy>=1.22.1,<=1.25.4"``
-    lower : str
+    lower : str | List[str]
         Newline-delimited packages requested,
          e.g. ``"pandas\nnumpy"``.
 
@@ -572,6 +647,7 @@ def get_lower_bounds(requirements: str | List[str], lower: str) -> str:
                 break
 
     lower_with_bounds = ""
+    lower_ = lower.split("\n") if isinstance(lower, str) else lower
     for pkg_name, lower_bound in all_lower_bounds.items():
         # TODO: Parse through extra requirements as well to get lower bounds
         if lower_bound is None:
@@ -579,7 +655,7 @@ def get_lower_bounds(requirements: str | List[str], lower: str) -> str:
                 "Requested %s lower bound, but did not find in install requirements.",
                 pkg_name,
             )
-        elif _isin_case_dashhyphen_ins(pkg_name, lower.split("\n")):
+        elif _isin_case_dashhyphen_ins(pkg_name, lower_):
             lower_with_bounds += f"{pkg_name}=={lower_bound}\n"
 
     return lower_with_bounds

--- a/tests/test_integration_toml.py
+++ b/tests/test_integration_toml.py
@@ -30,6 +30,27 @@ keep_full_version = true
 max_supported_python = "3.14"
 """
 
+SETUP_TOML_TOOL = """
+[project]
+name = "toy_package"
+version = "0.1.0"
+description = "Fake description"
+requires-python = ">=3.10.0"
+dependencies = ["polars<=1.0.0"]
+
+[project.optional-dependencies]
+tests = ["pytest"]
+
+[tool.edgetest]
+extras = ["tests"]
+
+[tool.pyproject-fmt]
+column_width = 88
+indent = 4
+keep_full_version = true
+max_supported_python = "3.14"
+"""
+
 SETUP_TOML_LOWER = """
 [project]
 name = "toy_package"
@@ -45,6 +66,32 @@ tests = ["pytest"]
 extras = ["tests"]
 
 [edgetest.envs.lower_env]
+lower = ["polars"]
+
+[tool.pyproject-fmt]
+column_width = 88
+indent = 4
+keep_full_version = true
+max_supported_python = "3.14"
+"""
+
+
+SETUP_TOML_LOWER_TOOL = """
+[project]
+name = "toy_package"
+version = "0.1.0"
+description = "Fake description"
+requires-python = ">=3.10.0"
+dependencies = ["polars>=1.0.0,<=1.5.0"]
+
+[project.optional-dependencies]
+tests = ["pytest"]
+
+[tool.edgetest]
+extras = ["tests"]
+
+[[tool.edgetest.env]]
+name = "lower_env"
 lower = ["polars"]
 
 [tool.pyproject-fmt]
@@ -81,6 +128,35 @@ max_supported_python = "3.14"
 """
 
 
+SETUP_TOML_EXTRAS_TOOL = """
+[project]
+name = "toy_package"
+version = "0.1.0"
+description = "Fake description"
+requires-python = ">=3.10.0"
+dependencies = ["Scikit_Learn>=1.7.0,<=1.7.2", "Polars[pyarrow]>=1.0.0,<=1.5.0"]
+
+[project.optional-dependencies]
+tests = ["pytest"]
+
+[[tool.edgetest.env]]
+name = "core"
+extras = ["tests"]
+upgrade = ["scikit-learn", "polars[pyarrow]"]
+
+[[tool.edgetest.env]]
+name = "lower_env"
+extras = ["tests"]
+lower = ["scikit-learn", "polars[pyarrow]"]
+
+[tool.pyproject-fmt]
+column_width = 88
+indent = 4
+keep_full_version = true
+max_supported_python = "3.14"
+"""
+
+
 SETUP_PY = """
 from setuptools import setup
 
@@ -104,13 +180,14 @@ PY_VER = f"python{sys.version_info.major}.{sys.version_info.minor}"
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @pytest.mark.integration
-def test_toy_package():
+@pytest.mark.parametrize("toml_source", [SETUP_TOML, SETUP_TOML_TOOL])
+def test_toy_package(toml_source):
     """Test using edgetest with a toy package."""
     runner = CliRunner()
 
     with runner.isolated_filesystem() as loc:
         with open("pyproject.toml", "w") as outfile:
-            outfile.write(SETUP_TOML)
+            outfile.write(toml_source)
         with open("setup.py", "w") as outfile:
             outfile.write(SETUP_PY)
         # Make a directory for the module
@@ -138,13 +215,14 @@ def test_toy_package():
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @pytest.mark.integration
-def test_toy_package_lower():
+@pytest.mark.parametrize("toml_source", [SETUP_TOML_LOWER, SETUP_TOML_LOWER_TOOL])
+def test_toy_package_lower(toml_source):
     """Test using edgetest with a toy package."""
     runner = CliRunner()
 
     with runner.isolated_filesystem() as loc:
         with open("pyproject.toml", "w") as outfile:
-            outfile.write(SETUP_TOML_LOWER)
+            outfile.write(toml_source)
         with open("setup.py", "w") as outfile:
             outfile.write(SETUP_PY)
         # Make a directory for the module
@@ -171,13 +249,14 @@ def test_toy_package_lower():
 
 
 @pytest.mark.integration
-def test_toy_package_extras():
+@pytest.mark.parametrize("toml_source", [SETUP_TOML_EXTRAS, SETUP_TOML_EXTRAS_TOOL])
+def test_toy_package_extras(toml_source):
     """Test using edgetest with a toy package."""
     runner = CliRunner()
 
     with runner.isolated_filesystem() as loc:
         with open("pyproject.toml", "w") as outfile:
-            outfile.write(SETUP_TOML_EXTRAS)
+            outfile.write(toml_source)
         with open("setup.py", "w") as outfile:
             outfile.write(SETUP_PY)
         # Make a directory for the module
@@ -214,15 +293,32 @@ def test_toy_package_extras():
 
         assert "polars[pyarrow]" in config["project"]["dependencies"][0]
         assert "scikit-learn" in config["project"]["dependencies"][1]
-        assert config["edgetest"]["envs"]["core"]["extras"] == ["tests"]
-        assert config["edgetest"]["envs"]["core"]["upgrade"] == [
-            "scikit-learn",
-            "polars[pyarrow]",
-        ]
-        assert config["edgetest"]["envs"]["lower_env"]["extras"] == ["tests"]
-        assert config["edgetest"]["envs"]["lower_env"]["lower"] == [
-            "scikit-learn",
-            "polars[pyarrow]",
-        ]
-        assert "polars" in result.stdout
-        assert "scikit-learn" in result.stdout
+
+        if (classic_ := config.get("edgetest")) is not None:
+            assert classic_["envs"]["core"]["extras"] == ["tests"]
+            assert classic_["envs"]["core"]["upgrade"] == [
+                "scikit-learn",
+                "polars[pyarrow]",
+            ]
+            assert classic_["envs"]["lower_env"]["extras"] == ["tests"]
+            assert classic_["envs"]["lower_env"]["lower"] == [
+                "scikit-learn",
+                "polars[pyarrow]",
+            ]
+            assert "polars" in result.stdout
+            assert "scikit-learn" in result.stdout
+        elif (tool_ := config.get("tool", {}).get("edgetest")) is not None:
+            assert tool_["env"][0]["name"] == "core"
+            assert tool_["env"][0]["extras"] == ["tests"]
+            assert tool_["env"][0]["upgrade"] == [
+                "scikit-learn",
+                "polars[pyarrow]",
+            ]
+            assert tool_["env"][1]["name"] == "lower_env"
+            assert tool_["env"][1]["extras"] == ["tests"]
+            assert tool_["env"][1]["lower"] == [
+                "scikit-learn",
+                "polars[pyarrow]",
+            ]
+            assert "polars" in result.stdout
+            assert "scikit-learn" in result.stdout

--- a/tests/test_interface_cfg.py
+++ b/tests/test_interface_cfg.py
@@ -4,6 +4,7 @@ import platform
 from pathlib import Path
 from unittest.mock import PropertyMock, call, patch
 
+import pytest
 from click.testing import CliRunner
 
 from edgetest.interface import cli
@@ -199,9 +200,10 @@ def test_cli_basic(mock_popen, mock_cpopen):
     assert result.output == TABLE_OUTPUT
 
 
+@pytest.mark.parametrize("ignore_cooldown", [True, False])
 @patch("edgetest.core.Popen", autospec=True)
 @patch("edgetest.utils.Popen", autospec=True)
-def test_cli_basic_cooldown(mock_popen, mock_cpopen):
+def test_cli_basic_cooldown(mock_popen, mock_cpopen, ignore_cooldown):
     """Test creating a basic environment with dependency cooldowns."""
     mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
     type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
@@ -214,7 +216,10 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
         with open("setup.cfg", "w") as outfile:
             outfile.write(SETUP_CFG_COOLDOWN)
 
-        result = runner.invoke(cli, ["--config=setup.cfg"])
+        if ignore_cooldown:
+            result = runner.invoke(cli, ["--config=setup.cfg", "--ignore-cooldown"])
+        else:
+            result = runner.invoke(cli, ["--config=setup.cfg"])
 
     assert result.exit_code == 0
 
@@ -223,6 +228,18 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
         py_loc = env_loc / "Scripts" / "python.exe"
     else:
         py_loc = env_loc / "bin" / "python"
+
+    # Upgrade installation argument depends on the parameterization
+    upgrade_callargs_ = [
+        "uv",
+        "pip",
+        "install",
+        f"--python={py_loc!s}",
+        "myupgrade",
+        "--upgrade",
+    ]
+    if not ignore_cooldown:
+        upgrade_callargs_.append("--exclude-newer=3 days")
 
     assert mock_popen.call_args_list == [
         call(
@@ -238,15 +255,7 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
             universal_newlines=True,
         ),
         call(
-            (
-                "uv",
-                "pip",
-                "install",
-                f"--python={py_loc!s}",
-                "myupgrade",
-                "--upgrade",
-                "--exclude-newer=3 days",
-            ),
+            tuple(upgrade_callargs_),
             stdout=-1,
             stderr=-1,
             universal_newlines=True,

--- a/tests/test_interface_toml.py
+++ b/tests/test_interface_toml.py
@@ -4,6 +4,7 @@ import platform
 from pathlib import Path
 from unittest.mock import PropertyMock, call, patch
 
+import pytest
 from click.testing import CliRunner
 
 from edgetest.interface import cli
@@ -192,9 +193,10 @@ def test_cli_basic(mock_popen, mock_cpopen):
     assert result.output == TABLE_OUTPUT
 
 
+@pytest.mark.parametrize("ignore_cooldown", [True, False])
 @patch("edgetest.core.Popen", autospec=True)
 @patch("edgetest.utils.Popen", autospec=True)
-def test_cli_basic_cooldown(mock_popen, mock_cpopen):
+def test_cli_basic_cooldown(mock_popen, mock_cpopen, ignore_cooldown):
     """Test creating a basic environment with dependency cooldowns."""
     mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
     type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
@@ -207,7 +209,12 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
         with open("pyproject.toml", "w") as outfile:
             outfile.write(SETUP_TOML_COOLDOWN)
 
-        result = runner.invoke(cli, ["--config=pyproject.toml"])
+        if ignore_cooldown:
+            result = runner.invoke(
+                cli, ["--config=pyproject.toml", "--ignore-cooldown"]
+            )
+        else:
+            result = runner.invoke(cli, ["--config=pyproject.toml"])
 
     assert result.exit_code == 0
 
@@ -216,6 +223,18 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
         py_loc = env_loc / "Scripts" / "python.exe"
     else:
         py_loc = env_loc / "bin" / "python"
+
+    # Upgrade installation argument depends on the parameterization
+    upgrade_callargs_ = [
+        "uv",
+        "pip",
+        "install",
+        f"--python={py_loc!s}",
+        "myupgrade",
+        "--upgrade",
+    ]
+    if not ignore_cooldown:
+        upgrade_callargs_.append("--exclude-newer=3 days")
 
     assert mock_popen.call_args_list == [
         call(
@@ -231,15 +250,7 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen):
             universal_newlines=True,
         ),
         call(
-            (
-                "uv",
-                "pip",
-                "install",
-                f"--python={py_loc!s}",
-                "myupgrade",
-                "--upgrade",
-                "--exclude-newer=3 days",
-            ),
+            tuple(upgrade_callargs_),
             stdout=-1,
             stderr=-1,
             universal_newlines=True,

--- a/tests/test_interface_toml.py
+++ b/tests/test_interface_toml.py
@@ -21,6 +21,13 @@ upgrade = ["myupgrade"]
 command = "pytest tests -m 'not integration'"
 """
 
+SETUP_TOML_TOOL = """
+[[tool.edgetest.env]]
+name = "myenv"
+upgrade = [ "myupgrade" ]
+command = "pytest tests -m 'not integration'"
+"""
+
 SETUP_TOML_COOLDOWN = """[edgetest]
 exclude_newer = "3 days"
 
@@ -36,6 +43,19 @@ dependencies = [
 ]
 
 [edgetest.envs.myenv_lower]
+lower = [ "mylower" ]
+command = "pytest tests -m 'not integration'"
+"""
+
+SETUP_TOML_LOWER_TOOL = """
+[project]
+dependencies = [
+  "myupgrade<=0.1.5",
+  "mylower<=0.1,>=0.0.1"
+]
+
+[[tool.edgetest.env]]
+name = "myenv_lower"
 lower = [ "mylower" ]
 command = "pytest tests -m 'not integration'"
 """
@@ -57,11 +77,31 @@ extras = [ "myextra" ]
 command = "pytest tests -m 'not integration'"
 """
 
+SETUP_TOML_EXTRAS_TOOL = """[project]
+optional-dependencies.myextra = [ "myupgrade<=0.1.5" ]
+
+[[tool.edgetest.env]]
+name = "myenv"
+upgrade = [ "myupgrade" ]
+extras = [ "myextra" ]
+command = "pytest tests -m 'not integration'"
+"""
+
 
 SETUP_TOML_EXTRAS_UPGRADE = """[project]
 optional-dependencies.myextra = ["myupgrade<=0.2.0"]
 
 [edgetest.envs.myenv]
+upgrade = [ "myupgrade" ]
+extras = [ "myextra" ]
+command = "pytest tests -m 'not integration'"
+"""
+
+SETUP_TOML_EXTRAS_UPGRADE_TOOL = """[project]
+optional-dependencies.myextra = ["myupgrade<=0.2.0"]
+
+[[tool.edgetest.env]]
+name = "myenv"
 upgrade = [ "myupgrade" ]
 extras = [ "myextra" ]
 command = "pytest tests -m 'not integration'"
@@ -118,9 +158,10 @@ all-requirements  True                True             myupgrade                
 """
 
 
+@pytest.mark.parametrize("toml_source", [SETUP_TOML, SETUP_TOML_TOOL])
 @patch("edgetest.core.Popen", autospec=True)
 @patch("edgetest.utils.Popen", autospec=True)
-def test_cli_basic(mock_popen, mock_cpopen):
+def test_cli_basic(mock_popen, mock_cpopen, toml_source):
     """Test creating a basic environment."""
     mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
     type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
@@ -131,7 +172,7 @@ def test_cli_basic(mock_popen, mock_cpopen):
 
     with runner.isolated_filesystem() as loc:
         with open("pyproject.toml", "w") as outfile:
-            outfile.write(SETUP_TOML)
+            outfile.write(toml_source)
 
         result = runner.invoke(cli, ["--config=pyproject.toml"])
 
@@ -279,9 +320,10 @@ def test_cli_basic_cooldown(mock_popen, mock_cpopen, ignore_cooldown):
     assert result.output == TABLE_OUTPUT
 
 
+@pytest.mark.parametrize("toml_source", [SETUP_TOML_LOWER, SETUP_TOML_LOWER_TOOL])
 @patch("edgetest.core.Popen", autospec=True)
 @patch("edgetest.utils.Popen", autospec=True)
-def test_cli_basic_lower(mock_popen, mock_cpopen):
+def test_cli_basic_lower(mock_popen, mock_cpopen, toml_source):
     """Test creating a basic environment."""
     mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
     type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
@@ -292,7 +334,7 @@ def test_cli_basic_lower(mock_popen, mock_cpopen):
 
     with runner.isolated_filesystem() as loc:
         with open("pyproject.toml", "w") as outfile:
-            outfile.write(SETUP_TOML_LOWER)
+            outfile.write(toml_source)
 
         result = runner.invoke(cli, ["--config=pyproject.toml"])
 
@@ -500,9 +542,16 @@ def test_cli_setup_reqs_update(mock_popen, mock_cpopen):
     assert out == SETUP_TOML_REQS_UPGRADE
 
 
+@pytest.mark.parametrize(
+    "toml_source, toml_output",
+    [
+        (SETUP_TOML_EXTRAS, SETUP_TOML_EXTRAS_UPGRADE),
+        (SETUP_TOML_EXTRAS_TOOL, SETUP_TOML_EXTRAS_UPGRADE_TOOL),
+    ],
+)
 @patch("edgetest.core.Popen", autospec=True)
 @patch("edgetest.utils.Popen", autospec=True)
-def test_cli_setup_extras_update(mock_popen, mock_cpopen):
+def test_cli_setup_extras_update(mock_popen, mock_cpopen, toml_source, toml_output):
     """Test running tests and updating extra installation requirements in a ``pyproject.toml`` file."""
     mock_popen.return_value.communicate.return_value = (PIP_LIST, "error")
     type(mock_popen.return_value).returncode = PropertyMock(return_value=0)
@@ -513,7 +562,7 @@ def test_cli_setup_extras_update(mock_popen, mock_cpopen):
 
     with runner.isolated_filesystem() as loc:
         with open("pyproject.toml", "w") as outfile:
-            outfile.write(SETUP_TOML_EXTRAS)
+            outfile.write(toml_source)
 
         result = runner.invoke(cli, ["--config=pyproject.toml", "--export"])
 
@@ -522,7 +571,7 @@ def test_cli_setup_extras_update(mock_popen, mock_cpopen):
 
     assert result.exit_code == 0
 
-    assert out == SETUP_TOML_EXTRAS_UPGRADE
+    assert out == toml_output
 
 
 @patch("edgetest.core.Popen", autospec=True)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -43,13 +44,29 @@ def test_create_environment(mock_run):
         create_environment("test", "test", {"python_version": "3.10"})
 
 
+@pytest.mark.parametrize("ignore_cooldown", [True, False])
+@patch("edgetest.lib.click.get_current_context")
 @patch("edgetest.lib._run_command", autospec=True)
-def test_run_update(mock_run):
+def test_run_update(mock_run, mock_ctx, ignore_cooldown):
+    mock_ctx.return_value = SimpleNamespace(params={"ignore_cooldown": ignore_cooldown})
     python_path = path_to_python("test", "test")
-    run_update("test", "test", ["1", "2"], {"test": "test"})
-    mock_run.assert_called_with(
-        "uv", "pip", "install", f"--python={python_path}", "1", "2", "--upgrade"
-    )
+    run_update("test", "test", ["1", "2"], {"exclude_newer": "3 days"})
+
+    if ignore_cooldown:
+        mock_run.assert_called_with(
+            "uv", "pip", "install", f"--python={python_path}", "1", "2", "--upgrade"
+        )
+    else:
+        mock_run.assert_called_with(
+            "uv",
+            "pip",
+            "install",
+            f"--python={python_path}",
+            "1",
+            "2",
+            "--upgrade",
+            "--exclude-newer=3 days",
+        )
 
     mock_run.side_effect = RuntimeError()
     with pytest.raises(RuntimeError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,10 @@
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
-from tomlkit import array, string
+import pytest
 
 from edgetest.schema import BASE_SCHEMA, EdgetestValidator, Schema
 from edgetest.utils import (
-    _convert_toml_array_to_string,
     _isin_case_dashhyphen_ins,
     gen_requirements_config,
     get_lower_bounds,
@@ -107,6 +106,19 @@ command = "pytest tests -m 'not integration'"
 """
 
 
+TOML_NOREQS_TOOL = """
+[[tool.edgetest.env]]
+name = "myenv"
+upgrade = [ "myupgrade" ]
+command = "pytest tests -m 'not integration'"
+
+[[tool.edgetest.env]]
+name = "myenv_lower"
+lower = [ "mylower" ]
+command = "pytest tests -m 'not integration'"
+"""
+
+
 TOML_REQS = """
 [project]
 dependencies = [
@@ -124,16 +136,40 @@ extras = ["tests"]
 command = "pytest tests -m 'not integration'"
 """
 
+
+TOML_REQS_DEFAULTS_TOOL = """
+[project]
+dependencies = [ "myupgrade" ]
+
+[tool.edgetest]
+extras = [ "tests" ]
+command = "pytest tests -m 'not integration'"
+"""
+
+
 TOML_REQS_COOLDOWN = """
 [project]
 dependencies = [
     "myupgrade"
 ]
+
 [edgetest]
 extras = ["tests"]
 command = "pytest tests -m 'not integration'"
 exclude_newer = "3 days"
 """
+
+
+TOML_REQS_COOLDOWN_TOOL = """
+[project]
+dependencies = [ "myupgrade" ]
+
+[tool.edgetest]
+extras = [ "tests" ]
+command = "pytest tests -m 'not integration'"
+exclude_newer = "3 days"
+"""
+
 
 TOML_NOREQS_DEFAULTS = """
 [edgetest]
@@ -149,6 +185,23 @@ lower = ["mylower"]
 command = "pytest tests"
 """
 
+TOML_NOREQS_DEFAULTS_TOOL = """
+[tool.edgetest]
+extras = [ "tests" ]
+command = "pytest tests -m 'not integration'"
+
+[[tool.edgetest.env]]
+name = "myenv"
+upgrade = [ "myupgrade" ]
+command = "pytest tests"
+
+[[tool.edgetest.env]]
+name = "myenv_lower"
+lower = [ "mylower" ]
+command = "pytest tests"
+"""
+
+
 TOML_CUSTOM = """
 [edgetest]
 extras = ["tests"]
@@ -162,6 +215,24 @@ upgrade = ["myupgrade"]
 
 [edgetest.envs.myenv_lower]
 lower = ["mylower"]
+"""
+
+
+TOML_CUSTOM_TOOL = """
+[tool.edgetest]
+extras = [ "tests" ]
+command = "pytest tests -m 'not integration'"
+
+[tool.edgetest.custom]
+mycustom = "mykey"
+
+[[tool.edgetest.env]]
+name = "myenv"
+upgrade = [ "myupgrade" ]
+
+[[tool.edgetest.env]]
+name = "myenv_lower"
+lower = [ "mylower" ]
 """
 
 
@@ -373,12 +444,13 @@ def test_parse_custom_cfg(tmpdir):
     assert validator.validate(cfg)
 
 
-def test_parse_toml(tmpdir):
+@pytest.mark.parametrize("toml_source", [TOML_NOREQS, TOML_NOREQS_TOOL])
+def test_parse_toml(tmpdir, toml_source):
     """Test parsing a config with no install requirements."""
     location = tmpdir.mkdir("mylocation")
     conf_loc = Path(str(location), "myconfig.toml")
     with open(conf_loc, "w") as outfile:
-        outfile.write(TOML_NOREQS)
+        outfile.write(toml_source)
 
     toml = parse_toml(filename=conf_loc)
 
@@ -386,12 +458,12 @@ def test_parse_toml(tmpdir):
         "envs": [
             {
                 "name": "myenv",
-                "upgrade": "myupgrade",
+                "upgrade": ["myupgrade"],
                 "command": "pytest tests -m 'not integration'",
             },
             {
                 "name": "myenv_lower",
-                "lower": "mylower",
+                "lower": ["mylower"],
                 "command": "pytest tests -m 'not integration'",
             },
         ]
@@ -402,12 +474,15 @@ def test_parse_toml(tmpdir):
     assert validator.validate(toml)
 
 
-def test_parse_toml_default(tmpdir):
+@pytest.mark.parametrize(
+    "toml_source", [TOML_NOREQS_DEFAULTS, TOML_NOREQS_DEFAULTS_TOOL]
+)
+def test_parse_toml_default(tmpdir, toml_source):
     """Test parsing a config with no install requirements and defaults."""
     location = tmpdir.mkdir("mylocation")
     conf_loc = Path(str(location), "myconfig.toml")
     with open(conf_loc, "w") as outfile:
-        outfile.write(TOML_NOREQS_DEFAULTS)
+        outfile.write(toml_source)
 
     toml = parse_toml(filename=conf_loc)
 
@@ -415,14 +490,14 @@ def test_parse_toml_default(tmpdir):
         "envs": [
             {
                 "name": "myenv",
-                "upgrade": "myupgrade",
-                "extras": "tests",
+                "upgrade": ["myupgrade"],
+                "extras": ["tests"],
                 "command": "pytest tests",
             },
             {
                 "name": "myenv_lower",
-                "lower": "mylower",
-                "extras": "tests",
+                "lower": ["mylower"],
+                "extras": ["tests"],
                 "command": "pytest tests",
             },
         ]
@@ -454,12 +529,13 @@ def test_parse_toml_reqs(tmpdir):
     assert validator.validate(toml)
 
 
-def test_parse_toml_reqs_default(tmpdir):
+@pytest.mark.parametrize("toml_source", [TOML_REQS_DEFAULTS, TOML_REQS_DEFAULTS_TOOL])
+def test_parse_toml_reqs_default(tmpdir, toml_source):
     """Test parsing a TOML style config with default arguments."""
     location = tmpdir.mkdir("mylocation")
     conf_loc = Path(str(location), "pyproject.toml")
     with open(conf_loc, "w") as outfile:
-        outfile.write(TOML_REQS_DEFAULTS)
+        outfile.write(toml_source)
 
     toml = parse_toml(filename=conf_loc)
 
@@ -468,13 +544,13 @@ def test_parse_toml_reqs_default(tmpdir):
             {
                 "name": "myupgrade",
                 "upgrade": "myupgrade",
-                "extras": "tests",
+                "extras": ["tests"],
                 "command": "pytest tests -m 'not integration'",
             },
             {
                 "name": "all-requirements",
                 "upgrade": "myupgrade",
-                "extras": "tests",
+                "extras": ["tests"],
                 "command": "pytest tests -m 'not integration'",
             },
         ]
@@ -485,12 +561,13 @@ def test_parse_toml_reqs_default(tmpdir):
     assert validator.validate(toml)
 
 
-def test_parse_toml_cooldown(tmpdir):
+@pytest.mark.parametrize("toml_source", [TOML_REQS_COOLDOWN, TOML_REQS_COOLDOWN_TOOL])
+def test_parse_toml_cooldown(tmpdir, toml_source):
     """Test parsing a config with a dependency cooldown."""
     location = tmpdir.mkdir("mylocation")
     conf_loc = Path(str(location), "myconfig.toml")
     with open(conf_loc, "w") as outfile:
-        outfile.write(TOML_REQS_COOLDOWN)
+        outfile.write(toml_source)
 
     toml = parse_toml(filename=conf_loc)
 
@@ -499,14 +576,14 @@ def test_parse_toml_cooldown(tmpdir):
             {
                 "name": "myupgrade",
                 "upgrade": "myupgrade",
-                "extras": "tests",
+                "extras": ["tests"],
                 "command": "pytest tests -m 'not integration'",
                 "exclude_newer": "3 days",
             },
             {
                 "name": "all-requirements",
                 "upgrade": "myupgrade",
-                "extras": "tests",
+                "extras": ["tests"],
                 "command": "pytest tests -m 'not integration'",
                 "exclude_newer": "3 days",
             },
@@ -514,12 +591,13 @@ def test_parse_toml_cooldown(tmpdir):
     }
 
 
-def test_parse_custom_toml(tmpdir):
+@pytest.mark.parametrize("toml_source", [TOML_CUSTOM, TOML_CUSTOM_TOOL])
+def test_parse_custom_toml(tmpdir, toml_source):
     """Test parsing a custom configuration."""
     location = tmpdir.mkdir("mylocation")
     conf_loc = Path(str(location), "pyproject.toml")
     with open(conf_loc, "w") as outfile:
-        outfile.write(TOML_CUSTOM)
+        outfile.write(toml_source)
 
     toml = parse_toml(filename=conf_loc)
 
@@ -528,14 +606,14 @@ def test_parse_custom_toml(tmpdir):
         "envs": [
             {
                 "name": "myenv",
-                "upgrade": "myupgrade",
-                "extras": "tests",
+                "upgrade": ["myupgrade"],
+                "extras": ["tests"],
                 "command": "pytest tests -m 'not integration'",
             },
             {
                 "name": "myenv_lower",
-                "lower": "mylower",
-                "extras": "tests",
+                "lower": ["mylower"],
+                "extras": ["tests"],
                 "command": "pytest tests -m 'not integration'",
             },
         ],
@@ -549,14 +627,6 @@ def test_parse_custom_toml(tmpdir):
     validator = EdgetestValidator(schema=schema.schema)
 
     assert validator.validate(toml)
-
-
-def test_convert_toml_array_to_string():
-    test_array = array("['a','b','c', 'd']")
-    test_string = string("abcd")
-
-    assert _convert_toml_array_to_string(test_array) == "a\nb\nc\nd"
-    assert _convert_toml_array_to_string(test_string) == "abcd"
 
 
 def test_upgrade_setup_cfg(tmpdir):


### PR DESCRIPTION
## Description

In #142 we introduced dependency cooldowns via `UV`. Here I'm adding a simple CLI flag that allows users to ignore the cooldown at runtime.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
